### PR TITLE
Disable broken semantic-release Github success step 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 - Closes <!-- issue number here. e.g. "Closes #1234" -->
 
-### User facing changelog
+### User-facing changelog
 
 <!-- Explain the change(s) for every user to read in our changelog. Examples: https://github.com/dimazuien/react-router-scroll-to-top/blob/main/CHANGELOG.md -->
 

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,6 +6,12 @@
     "@semantic-release/changelog",
     "@semantic-release/npm",
     "@semantic-release/git",
-    "@semantic-release/github"
+    [
+      "@semantic-release/github",
+      {
+        "successComment": false,
+        "failTitle": false
+      }
+    ]
   ]
 }


### PR DESCRIPTION
During the release, the final CI step failed. Although the new version of the package was released correctly, the last step seems to be safe to disable.

See more details here: https://github.com/semantic-release/semantic-release/issues/2204